### PR TITLE
fix: upgrade shell-quote to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
     "@babel/traverse": "7.28.4",
     "base-x": "3.0.11",
     "cross-spawn": "7.0.6",
+    "shell-quote": "1.8.4",
     "webpack-dev-middleware": "5.3.4",
     "axios": "1.15.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9596,10 +9596,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@^1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
-  integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
+shell-quote@1.8.4, shell-quote@^1.7.3:
+  version "1.8.4"
+  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
+  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
 
 side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## Summary
- Add a Yarn resolution for `shell-quote@1.8.4` to address the reported critical command injection vulnerability.
- Refresh `yarn.lock` so `react-dev-utils` resolves `shell-quote` to `1.8.4` instead of `1.7.3`.

## Verification
- `yarn why shell-quote` shows `shell-quote@1.8.4` hoisted from `react-dev-utils#shell-quote`.
- `yarn build` completes successfully.

## Notes
- Build still reports existing warnings for outdated Browserslist data, an autoprefixer `color-adjust` deprecation, and unused variables in `src/components/Modal/index.tsx`.